### PR TITLE
Make substitute public

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -52,7 +52,7 @@ fn is_registry(token: &str) -> bool {
 /// 16.
 /// If None is returned, substitution was impossible, either because a
 /// referenced variable did not exist, or recursion depth was exceeded.
-fn substitute<'a, 'b>(
+pub fn substitute<'a, 'b>(
   s: &'a str,
   vars: &'b HashMap<&'b str, &'b str>,
   used_vars: &mut HashSet<String>,


### PR DESCRIPTION
The `resolve_vars` functionality is a method on `FromInstruction` ([as seen in this test](https://github.com/modal-labs/dockerfile-parser-rs/blob/master/src/image.rs#L552)). 

My understanding is that `resolve_vars` populates a hash map with `dockerfile.global_args` then calls `substitute`.

We can use `substitute` method for more use cases, so making it public here.

My guess as to why `resolve_vars` is only a method on `image_ref` is because the parser doesn't keep track of the `env` and `arg` variables as it parses, so it doesn't know what to pass to `substitute`.


Also, `substitute` currently doesn't support more advanced syntax like `${BAR:0:2}`