### PR TITLE
Fixed bug related to incorrect heredoc body parsing

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -105,7 +105,8 @@ string_array = _{
 heredoc_op = _{ "<<" }
 heredoc_delim = { (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = { heredoc_delim ~ NEWLINE }
-heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
+heredoc_line = @{ !(heredoc_delim ~ NEWLINE) ~ (!NEWLINE ~ ANY)* ~ NEWLINE }
+heredoc_body = @{ heredoc_line* }
 
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -370,6 +370,34 @@ mod tests {
 
     Ok(())
   }
+  
+  #[test]
+  fn copy_heredoc_simple() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          COPY <<EOF /tmp/test.txt
+          hello world
+          EOF
+        "#),
+        Rule::copy
+      )?.into_copy().unwrap(),
+      CopyInstruction {
+        span: Span { start: 0, end: 41 },
+        flags: vec![],
+        sources: vec![SourceType::FileContents(SpannedString {
+          span: Span::new(25, 37),
+          content: "hello world\n".to_string(),
+        })],
+        destination: SpannedString {
+          span: Span::new(11, 24),
+          content: "/tmp/test.txt".to_string(),
+        },
+      }.into()
+    );
+
+    Ok(())
+  }
 
   #[test]
   fn copy_heredoc_incorrect() -> Result<()> {


### PR DESCRIPTION
Recently added [heredoc parsing](https://github.com/modal-labs/dockerfile-parser-rs/pull/2) did not have correct grammar, but tests didn't catch it because all the `copy` heredocs tests were html syntax, which happened to match the incorrect grammar. This PR fixes the issue and includes a corresponding test in `copy.rs`.