### PR TITLE
support quoted and dash-prefixed heredoc delimiters in RUN

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -105,11 +105,19 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
-heredoc_op = _{ "<<" }
+// "<<" or "<<-" (dash variant strips leading tabs from body and terminator)
+heredoc_op = _{ "<<" ~ "-"? }
 heredoc_delim_str = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 
-heredoc_delim = _{ PUSH(heredoc_delim_str) }
-heredoc_terminator = _{ POP }
+// allow optional surrounding ' or " on the open form; the PUSHed token is
+// always the unquoted name, so the terminator matches `EOF` not `'EOF'`
+heredoc_delim = _{
+    ("'" ~ PUSH(heredoc_delim_str) ~ "'")
+  | ("\"" ~ PUSH(heredoc_delim_str) ~ "\"")
+  | PUSH(heredoc_delim_str)
+}
+// terminator: optional leading tabs (for <<- support) then the POPped name
+heredoc_terminator = _{ "\t"* ~ POP }
 heredoc_line = @{ !(heredoc_terminator) ~ any_eol ~ NEWLINE }
 heredoc_body = @{ heredoc_line* }
 

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -644,6 +644,128 @@ mod tests {
   }
 
   #[test]
+  fn run_heredoc_single_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN cat <<'EOF'
+        hello
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 25),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 25),
+            content: "<<'EOF'\nhello\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_double_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN cat <<"EOF"
+        hello
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 25),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 25),
+            content: "<<\"EOF\"\nhello\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_dash() -> Result<()> {
+    assert_eq!(
+      parse_single("RUN cat <<-EOF\n\thello\n\tEOF\n", Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 26),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 26),
+            content: "<<-EOF\n\thello\n\tEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_dash_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single("RUN cat <<-'EOF'\n\thello\n\tEOF\n", Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 28),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 28),
+            content: "<<-'EOF'\n\thello\n\tEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_quoted_preserves_dollar_signs() -> Result<()> {
+    let ins = parse_single(indoc!(r#"RUN cat > /f <<'EOF'
+      echo $VAR ${BRACE}
+      EOF
+    "#), Rule::run)?.into_run().unwrap();
+
+    let (_, heredoc) = ins.expr.as_shell_with_heredoc().unwrap();
+    assert_eq!(heredoc.content, "<<'EOF'\necho $VAR ${BRACE}\nEOF");
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_repro_from_bug_report() -> Result<()> {
+    let ins = parse_single(indoc!(r#"RUN cat > /test.conf << 'EOF'
+      server {
+          listen 80;
+      }
+      EOF
+    "#), Rule::run)?.into_run().unwrap();
+
+    let (breakable, heredoc) = ins.expr.as_shell_with_heredoc().unwrap();
+    assert_eq!(breakable.to_string(), "cat > /test.conf ");
+    assert_eq!(
+      heredoc.content,
+      "<< 'EOF'\nserver {\n    listen 80;\n}\nEOF"
+    );
+
+    Ok(())
+  }
+
+  #[test]
   fn run_option_display() -> Result<()> {
     let ins = parse_single(r#"run --security=insecure --mount=type=cache,target=/root echo hi"#, Rule::run)?
       .into_run().unwrap();

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -422,3 +422,35 @@ fn parse_from_sha256_digest_and_tag() -> Result<(), dockerfile_parser::Error> {
 
     Ok(())
 }
+
+#[test]
+fn parse_run_with_quoted_shell_heredoc() -> Result<(), dockerfile_parser::Error> {
+    let dockerfile = Dockerfile::parse(indoc!(
+        r#"
+            FROM ubuntu:24.04
+            RUN cat > /test.conf << 'EOF'
+            server {
+                listen 80;
+            }
+            EOF
+        "#
+    ))?;
+
+    assert_eq!(dockerfile.instructions.len(), 2);
+
+    let run = match &dockerfile.instructions[1] {
+        Instruction::Run(r) => r,
+        other => panic!("expected RUN, got {:?}", other),
+    };
+
+    let (breakable, heredoc) = run.expr.as_shell_with_heredoc().expect(
+        "shell heredoc with quoted delimiter should parse as ShellWithHeredoc, not fragment",
+    );
+    assert_eq!(breakable.to_string(), "cat > /test.conf ");
+    assert_eq!(
+        heredoc.content,
+        "<< 'EOF'\nserver {\n    listen 80;\n}\nEOF"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Real-world Dockerfiles commonly write config files inline using shell heredocs with quoted delimiters (`<< 'EOF'` or `<< "EOF"`) to suppress variable expansion, or with the `<<-` dash variant to allow tab-indented bodies. The previous grammar only accepted bare alphanumeric delimiters, so these inputs failed to parse — `any_breakable` consumed only the first line and the body lines were re-entered as separate (broken) instructions, surfacing downstream as opaque "Image build failed" errors.

Grammar changes (additive):
- `heredoc_op` accepts an optional trailing `-`.
- `heredoc_delim` accepts the bare name optionally wrapped in matching single or double quotes; the PUSHed token is always the unquoted name, so `<<'EOF'` is closed by `EOF` (matching bash semantics).
- `heredoc_terminator` tolerates leading tabs to support `<<-`.

No Rust changes are needed: `parse_heredoc` slurps `record.as_str()` verbatim, so `Heredoc::content` round-trips the original (quoted or dashed) source faithfully back to BuildKit.