### PR TITLE
support empty values in ENV key=value pairs

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -173,7 +173,8 @@ copy_heredoc = {
 copy = { ^"copy" ~ ( copy_heredoc |copy_standard) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
-env_pair_value = ${ any_whitespace }
+// like any_whitespace but allows zero chars, so `ENV FOO=` parses as FOO -> ""
+env_pair_value = ${ (!(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY)* }
 env_pair_quoted_value = ${ string }
 env_pair = @{ env_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair?)+ }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -85,8 +85,14 @@ any_breakable = ${
 // consumes any character until the end of the line
 any_eol = _{ (!NEWLINE ~ ANY)* }
 
+// a single character that can appear inside a whitespace-bounded token —
+// anything that isn't a token-ending newline, EOI, arg_ws boundary, or
+// heredoc operator. Used as the building block of `any_whitespace` (one+)
+// and `env_pair_value` (zero+).
+whitespace = _{ !(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY }
+
 // consumes all characters until the next whitespace
-any_whitespace = _{ (!(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY)+ }
+any_whitespace = _{ whitespace+ }
 
 // consumes identifier characters until the next whitespace
 identifier_whitespace = _{ (!ws ~ (ASCII_ALPHANUMERIC | "_" | "-"))+ }
@@ -182,7 +188,7 @@ copy = { ^"copy" ~ ( copy_heredoc |copy_standard) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 // like any_whitespace but allows zero chars, so `ENV FOO=` parses as FOO -> ""
-env_pair_value = ${ (!(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY)* }
+env_pair_value = ${ whitespace* }
 env_pair_quoted_value = ${ string }
 env_pair = @{ env_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair?)+ }

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -302,7 +302,7 @@ mod tests {
   }
 
   #[test]
-  fn env_empty_value() -> Result<()> {
+  fn parse_single_parses_env_with_empty_value() -> Result<()> {
     assert_eq!(
       parse_single(r#"env FOO="#, Rule::env)?.into_env().unwrap(),
       EnvInstruction {
@@ -322,7 +322,7 @@ mod tests {
   }
 
   #[test]
-  fn env_empty_value_then_pair() -> Result<()> {
+  fn parse_single_parses_env_with_empty_value_then_pair() -> Result<()> {
     assert_eq!(
       parse_single(r#"env FOO= BAR=baz"#, Rule::env)?.into_env().unwrap().vars,
       vec![
@@ -349,7 +349,7 @@ mod tests {
   }
 
   #[test]
-  fn env_pair_then_empty_value() -> Result<()> {
+  fn parse_single_parses_env_with_pair_then_empty_value() -> Result<()> {
     assert_eq!(
       parse_single(r#"env FOO=bar BAR="#, Rule::env)?.into_env().unwrap().vars,
       vec![
@@ -376,7 +376,7 @@ mod tests {
   }
 
   #[test]
-  fn env_empty_value_with_continuation() -> Result<()> {
+  fn parse_single_parses_env_with_empty_value_and_continuation() -> Result<()> {
     assert_eq!(
       parse_single("env FOO= \\\n  BAR=baz", Rule::env)?.into_env().unwrap().vars,
       vec![
@@ -403,7 +403,7 @@ mod tests {
   }
 
   #[test]
-  fn env_empty_value_round_trips_to_empty_string() -> Result<()> {
+  fn parse_single_env_with_empty_value_round_trips_to_empty_string() -> Result<()> {
     let env = parse_single(r#"env FOO="#, Rule::env)?.into_env().unwrap();
     assert_eq!(env.vars.len(), 1);
     assert_eq!(env.vars[0].key.content, "FOO");

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -302,6 +302,118 @@ mod tests {
   }
 
   #[test]
+  fn env_empty_value() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"env FOO="#, Rule::env)?.into_env().unwrap(),
+      EnvInstruction {
+        span: Span::new(0, 8),
+        vars: vec![EnvVar::new(
+          Span::new(4, 8),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "FOO".to_string(),
+          },
+          ((8, 8), ""),
+        )],
+      }
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn env_empty_value_then_pair() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"env FOO= BAR=baz"#, Rule::env)?.into_env().unwrap().vars,
+      vec![
+        EnvVar::new(
+          Span::new(4, 8),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "FOO".to_string(),
+          },
+          ((8, 8), "")
+        ),
+        EnvVar::new(
+          Span::new(9, 16),
+          SpannedString {
+            span: Span::new(9, 12),
+            content: "BAR".to_string(),
+          },
+          ((13, 16), "baz")
+        ),
+      ]
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn env_pair_then_empty_value() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"env FOO=bar BAR="#, Rule::env)?.into_env().unwrap().vars,
+      vec![
+        EnvVar::new(
+          Span::new(4, 11),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "FOO".to_string(),
+          },
+          ((8, 11), "bar")
+        ),
+        EnvVar::new(
+          Span::new(12, 16),
+          SpannedString {
+            span: Span::new(12, 15),
+            content: "BAR".to_string(),
+          },
+          ((16, 16), "")
+        ),
+      ]
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn env_empty_value_with_continuation() -> Result<()> {
+    assert_eq!(
+      parse_single("env FOO= \\\n  BAR=baz", Rule::env)?.into_env().unwrap().vars,
+      vec![
+        EnvVar::new(
+          Span::new(4, 8),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "FOO".to_string(),
+          },
+          ((8, 8), "")
+        ),
+        EnvVar::new(
+          Span::new(13, 20),
+          SpannedString {
+            span: Span::new(13, 16),
+            content: "BAR".to_string(),
+          },
+          ((17, 20), "baz")
+        ),
+      ]
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn env_empty_value_round_trips_to_empty_string() -> Result<()> {
+    let env = parse_single(r#"env FOO="#, Rule::env)?.into_env().unwrap();
+    assert_eq!(env.vars.len(), 1);
+    assert_eq!(env.vars[0].key.content, "FOO");
+    assert_eq!(env.vars[0].value.to_string(), "");
+    assert!(env.vars[0].value.span.start <= env.vars[0].value.span.end);
+
+    Ok(())
+  }
+
+  #[test]
   fn test_multiline_pairs() -> Result<()> {
     // note: docker allows empty line continuations (but may print a warning)
     assert_eq!(

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -422,3 +422,23 @@ fn parse_from_sha256_digest_and_tag() -> Result<(), dockerfile_parser::Error> {
 
     Ok(())
 }
+
+#[test]
+fn parse_env_with_empty_value() -> Result<(), dockerfile_parser::Error> {
+    let dockerfile = Dockerfile::parse(
+        "FROM ubuntu:24.04\nENV FOO=\nRUN echo done\n",
+    )?;
+
+    assert_eq!(dockerfile.instructions.len(), 3);
+
+    let env = match &dockerfile.instructions[1] {
+        Instruction::Env(e) => e,
+        other => panic!("expected ENV, got {:?}", other),
+    };
+
+    assert_eq!(env.vars.len(), 1);
+    assert_eq!(env.vars[0].key.content, "FOO");
+    assert_eq!(env.vars[0].value.to_string(), "");
+
+    Ok(())
+}


### PR DESCRIPTION
Real-world Dockerfiles commonly use `ENV FOO=` to set an environment variable to the empty string with the `=` form. The previous grammar required `env_pair_value` to be at least one character (`any_whitespace` uses `+`), so `ENV FOO=` failed to parse and the body was left unconsumed before the next newline, surfacing downstream as a generic "Image build failed" error.

The other empty-value forms — `ENV FOO=""` (quoted) and the legacy `ENV FOO ""` (single form) — already worked because they route through different rules.

Grammar change: replace the single line

    env_pair_value = ${ any_whitespace }

with a zero-or-more variant inlined just for the env-pair use case. `any_whitespace` itself is left at `+` since it's reused by `from_flag_value`, `arg_value`, `copy_pathspec`, `run_option_value`, and `label_value` — none of which should accept empty.

No Rust changes are needed: `parse_env_pair` already feeds `field.as_str()` straight into `BreakableString::add_string`, which handles the empty-string case cleanly (zero-length span at the position right after the `=`, one component containing `""`).