### PR TITLE
support bare boolean COPY flags (e.g. `--link`)

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -168,7 +168,10 @@ cmd = { ^"cmd" ~ arg_ws ~ (cmd_exec | cmd_shell) }
 
 copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
-copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
+// `=value` is optional so boolean flags like `--link` parse without a value;
+// the Rust layer (`CopyFlag::from_record`) substitutes "true" in that case,
+// matching BuildKit's `--link == --link=true` semantic.
+copy_flag = { "--" ~ copy_flag_name ~ ("=" ~ copy_flag_value)? }
 copy_pathspec = @{ any_whitespace }
 copy_standard = { (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
 copy_heredoc = {

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -38,9 +38,13 @@ impl CopyFlag {
       message: "copy flags require a key".into(),
     })?;
 
-    let value = value.ok_or_else(|| Error::GenericParseError {
-      message: "copy flags require a value".into()
-    })?;
+    // Boolean flags like `--link` parse without a `=value`. BuildKit treats
+    // bare `--link` as equivalent to `--link=true`, so we synthesize that here
+    // rather than push the Optional all the way through the public CopyFlag API.
+    let value = value.unwrap_or_else(|| SpannedString {
+      span,
+      content: "true".to_string(),
+    });
 
     Ok(CopyFlag {
       span, name, value
@@ -266,6 +270,54 @@ mod tests {
       }.into()
     );
 
+    Ok(())
+  }
+
+  #[test]
+  fn copy_boolean_flag_bare() -> Result<()> {
+    // BuildKit's --link is a boolean flag and may appear without `=value`.
+    // The grammar accepts this; the synthesized value is "true".
+    let parsed = parse_single("copy --link foo bar", Rule::copy)?
+      .into_copy()
+      .unwrap();
+    assert_eq!(parsed.flags.len(), 1);
+    assert_eq!(parsed.flags[0].name.content, "link");
+    assert_eq!(parsed.flags[0].value.content, "true");
+    assert_eq!(parsed.sources.len(), 1);
+    match &parsed.sources[0] {
+      SourceType::FileName(s) => assert_eq!(s.content, "foo"),
+      _ => panic!("expected FileName source"),
+    }
+    assert_eq!(parsed.destination.content, "bar");
+    Ok(())
+  }
+
+  #[test]
+  fn copy_boolean_flag_with_explicit_value() -> Result<()> {
+    // The explicit `--link=true` / `--link=false` forms still work and the
+    // value round-trips literally.
+    let parsed = parse_single("copy --link=false foo bar", Rule::copy)?
+      .into_copy()
+      .unwrap();
+    assert_eq!(parsed.flags.len(), 1);
+    assert_eq!(parsed.flags[0].name.content, "link");
+    assert_eq!(parsed.flags[0].value.content, "false");
+    Ok(())
+  }
+
+  #[test]
+  fn copy_boolean_flag_mixed_with_valued_flag() -> Result<()> {
+    // Bare boolean flags compose with valued flags in any order.
+    let parsed = parse_single("copy --link --chmod=755 foo bar", Rule::copy)?
+      .into_copy()
+      .unwrap();
+    assert_eq!(parsed.flags.len(), 2);
+    assert_eq!(parsed.flags[0].name.content, "link");
+    assert_eq!(parsed.flags[0].value.content, "true");
+    assert_eq!(parsed.flags[1].name.content, "chmod");
+    assert_eq!(parsed.flags[1].value.content, "755");
+    assert_eq!(parsed.sources.len(), 1);
+    assert_eq!(parsed.destination.content, "bar");
     Ok(())
   }
 


### PR DESCRIPTION
This is needed to fix failures in the CHMOD/CHOWN pr in the modal repo: https://github.com/modal-labs/modal/pull/40048

__

The previous grammar required `--name=value` for COPY flags, so a bare boolean flag like `--link` did not parse as a flag at all — it fell through to `copy_pathspec` and ended up in the source list, which in downstream consumers like Modal manifests as "copy_tree: source path does not exist" because the build context has no file named `--link`.

BuildKit treats `COPY --link foo dest` as equivalent to `COPY --link=true foo dest`. The grammar change makes the `=value` suffix optional; `CopyFlag::from_record` substitutes the literal string "true" when no value was parsed, so the public CopyFlag API remains non-Optional and existing consumers see consistent values.

Tests added:
- copy_boolean_flag_bare              — `--link` alone
- copy_boolean_flag_with_explicit_value — `--link=false` round-trips
- copy_boolean_flag_mixed_with_valued_flag — `--link --chmod=755`